### PR TITLE
Fix UtilitySelector unit test

### DIFF
--- a/Fluid-HTN-Ext.UnitTests/UtilitySelectorTest.cs
+++ b/Fluid-HTN-Ext.UnitTests/UtilitySelectorTest.cs
@@ -16,7 +16,7 @@ namespace Fluid_HTN_Ext.UnitTests
         {
             var domain = new DomainBuilder<MyContext>("test")
                 .UtilitySelect<DomainBuilder<MyContext>, MyContext>("utility select")
-                    .UtilityAction<DomainBuilder<MyContext>, MyContext, UtilityActionHighUtility>("high utility")
+                    .UtilityAction<DomainBuilder<MyContext>, MyContext, UtilityActionLowUtility>("low utility")
                         .Condition("Has not A", context => !context.HasState(MyWorldState.HasA))
                         .Do(context =>
                         {
@@ -25,7 +25,7 @@ namespace Fluid_HTN_Ext.UnitTests
                         })
                         .Effect("Has A", EffectType.PlanOnly, (context, type) => context.SetState(MyWorldState.HasA, true, type))
                     .End()
-                    .UtilityAction<DomainBuilder<MyContext>, MyContext, UtilityActionHighUtility>("low utility")
+                    .UtilityAction<DomainBuilder<MyContext>, MyContext, UtilityActionHighUtility>("high utility")
                         .Condition("Has not B", context => !context.HasState(MyWorldState.HasB))
                         .Do(context =>
                         {


### PR DESCRIPTION
"low utility" should be using UtilityActionLowUtility but it was using
UtilityActionHighUtility.

Also swapped the positions of "low utility" and "high utility" so that
"high utility" isn't chosen by default when scores are equal (as was
happening previously).